### PR TITLE
fix(bot): 修复私聊消息发送功能

### DIFF
--- a/api.md
+++ b/api.md
@@ -50,15 +50,16 @@ await bot.send_chat_message(message="Hello!", show=True)
 
 ---
 
-### **2.3 `send_whisper_message(message)`**
+### **2.3 `send_whisper_message(target, message)`**
 发送 **私聊消息**：
 
 ```python
-await bot.send_whisper_message(message="Hello EFChat!")
+await bot.send_whisper_message(target="105", message="Hello EFChat!")
 ```
 
 | 参数        | 类型 | 说明 |
 |------------|------|------|
+| `target`   | `str` | 目标用户昵称 |
 | `message`  | `str` 或 `MessageSegment` | 要发送的内容 |
 
 #### 返回

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nonebot-adapter-efchat"
-version = "0.1.4"
+version = "0.1.5"
 description = "A NoneBot adapter for EFChat"
 authors = ["molanp <molanpp@outlook.com>"]
 license = "MIT"
@@ -21,8 +21,8 @@ keywords = ["bot", "efchat", "wtek"]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-nonebot2 = "^2.2.0"
-typing-extensions = "^4.0.0"
+nonebot2 = ">=2.2.0"
+typing-extensions = ">=4.0.0"
 pydantic = ">=1.10.0,<3.0.0,!=2.5.0,!=2.5.1"
 aiofiles = ">=23.0.0"
 


### PR DESCRIPTION
- 更新 `send_whisper_message` 方法，增加 `target` 参数以指定接收者
- 修正 `target_method` 调用，传递正确的参数
- 更新 API 文档，反映 `send_whisper_message` 方法的变更
- 调整版本号至 0.1.5，并更新依赖版本

## Sourcery 总结

通过更新 `send_whisper_message` 以接受一个显式收件人、修正其调用方式、相应地更新文档，并提升包版本和依赖约束来修复私信发送功能。

缺陷修复:
- 修正 `target_method` 中私信消息的调用，以传递显式收件人和消息

功能增强:
- 为 `send_whisper_message` 添加一个 `target` 参数，用于指定收件人

构建:
- 将包版本提升至 0.1.5，并放宽 `nonebot2` 和 `typing-extensions` 的版本约束

文档:
- 更新 API 文档以反映新的 `send_whisper_message` 签名

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix private message sending by updating send_whisper_message to accept an explicit recipient, correct its invocation, update documentation accordingly, and bump the package version and dependency constraints.

Bug Fixes:
- Correct whisper message invocation in target_method to pass the explicit recipient and message

Enhancements:
- Add a `target` parameter to send_whisper_message for specifying the recipient

Build:
- Bump package version to 0.1.5 and loosen version constraints for nonebot2 and typing-extensions

Documentation:
- Update API documentation to reflect the new send_whisper_message signature

</details>